### PR TITLE
Preliminary 0.12 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "build": "eslint src && pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
-    "pulp": "^10.0.4",
-    "purescript-psa": "^0.5.0-rc.1",
-    "rimraf": "^2.6.1"
+    "eslint": "^4.7.2",
+    "pulp": "^12.0.1",
+    "purescript-psa": "^0.5.1",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/PSCI/Support.purs
+++ b/src/PSCI/Support.purs
@@ -17,10 +17,11 @@ import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 class Eval a where
   eval :: a -> Eff (console :: CONSOLE) Unit
 
-instance evalShow :: Show a => Eval a where
-  eval = logShow
-
 instance evalEff :: Eval a => Eval (Eff eff a) where
   eval x = do
     a <- unsafeCoerceEff x
     eval a
+else
+instance evalShow :: Show a => Eval a where
+  eval = logShow
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,16 @@
+module Test.Main where
+
+import Prelude (pure, unit, Unit)
+import PSCI.Support (eval)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, logShow)
+
+egEvalShow :: Eff (console :: CONSOLE) Unit
+egEvalShow = eval 42
+
+egEvalEff :: Eff (console :: CONSOLE) Unit
+egEvalEff = eval (logShow 42)
+
+main :: Eff () Unit
+main = pure unit
+


### PR DESCRIPTION
Uses an instance chain instead of overlapping instances for `Eval`.
Also fixes #2

Added a test to make sure the two use cases don't overlap - failed before the change, now passes.