### PR TITLE
fix: removes leftover 'else'

### DIFF
--- a/src/PSCI/Support.purs
+++ b/src/PSCI/Support.purs
@@ -18,7 +18,7 @@ class Eval a where
 
 instance evalEffect :: Eval a => Eval (Effect a) where
   eval x = x >>= eval
-else
+
 instance evalShow :: Show a => Eval a where
   eval = logShow
 


### PR DESCRIPTION
I'm just getting started with Purescript and have been experiencing some errors after running `pulp init` and `pulp build` in a fresh project. One of the errors points to this file. This loose 'else' really looks odd (but let me know if this is a valid syntax!)