### PR TITLE
Add instance for `Eval (Effect Unit)`

### DIFF
--- a/src/PSCI/Support.purs
+++ b/src/PSCI/Support.purs
@@ -16,6 +16,9 @@ import Effect.Console (logShow)
 class Eval a where
   eval :: a -> Effect Unit
 
+instance evalEffectUnit :: Eval (Effect Unit) where
+  eval = identity
+else
 instance evalEffect :: Eval a => Eval (Effect a) where
   eval x = x >>= eval
 else


### PR DESCRIPTION
This additional instance prevents "unit" from being printed after
evaluating an action of the type `Effect Unit`. This is what ghci does,
and it is usually what you want. For example:

Before:
```
> log "hello, world"
hello, world
unit
```

After:
```
> log "hello, world"
hello, world
```

(Just thought I'd go straight to opening a PR rather than first opening an issue to discuss because this is so easy to do implementation-wise)